### PR TITLE
change the form width relatively

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
 
       <h4>Save the date and pre-register:</h4>
 
-     <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScRCbqvj_A60HpHpE1C9dDXC-IbNz-ka5mtxkJ1iNxH3mMHxw/viewform?embedded=true" width="800" height="850" frameborder="0" marginheight="0" marginwidth="0" onload = "window.parent.scrollTo(0,0)">Loading…</iframe>
+     <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScRCbqvj_A60HpHpE1C9dDXC-IbNz-ka5mtxkJ1iNxH3mMHxw/viewform?embedded=true" width="100%" height="850" frameborder="0" marginheight="0" marginwidth="0" onload = "window.parent.scrollTo(0,0)">Loading…</iframe>
 
 
 <div class="docs-section" id="SOC">


### PR DESCRIPTION
This is just a simple modification to vary the width of the google form automatically according to the accessing devise size (in particular for smartphones or tablets)
It could be slightly helpful for participants who register from their mobile devices 👍 